### PR TITLE
fix: queue packet handler actions for missing entities

### DIFF
--- a/Fabric/src/main/java/com/yungnickyoung/minecraft/ribbits/client/RibbitsFabricClient.java
+++ b/Fabric/src/main/java/com/yungnickyoung/minecraft/ribbits/client/RibbitsFabricClient.java
@@ -7,8 +7,11 @@ import com.yungnickyoung.minecraft.ribbits.module.BlockModule;
 import com.yungnickyoung.minecraft.ribbits.module.EntityTypeModule;
 import com.yungnickyoung.minecraft.ribbits.module.NetworkModuleFabric;
 import com.yungnickyoung.minecraft.ribbits.module.ParticleTypeModule;
+import com.yungnickyoung.minecraft.ribbits.network.ClientPacketHandlerFabric;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.particle.v1.ParticleFactoryRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
@@ -31,5 +34,8 @@ public class RibbitsFabricClient implements ClientModInitializer {
 
         // Particle rendering
         ParticleFactoryRegistry.getInstance().register(ParticleTypeModule.SPELL.get(), RibbitSpellParticle.Factory::new);
+
+        ClientEntityEvents.ENTITY_LOAD.register((entity, world) -> ClientPacketHandlerFabric.onEntityLoad(entity));
+        ClientPlayConnectionEvents.DISCONNECT.register((handler, client) -> ClientPacketHandlerFabric.clearPendingActions());
     }
 }

--- a/Fabric/src/main/java/com/yungnickyoung/minecraft/ribbits/network/ClientPacketHandlerFabric.java
+++ b/Fabric/src/main/java/com/yungnickyoung/minecraft/ribbits/network/ClientPacketHandlerFabric.java
@@ -17,6 +17,7 @@ import com.yungnickyoung.minecraft.ribbits.services.Services;
 import com.yungnickyoung.minecraft.ribbits.util.BufferUtils;
 import net.fabricmc.fabric.api.networking.v1.PacketSender;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.FriendlyByteBuf;
@@ -25,24 +26,48 @@ import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
+import java.util.function.Consumer;
 
 public class ClientPacketHandlerFabric {
+    private static final Map<UUID, List<Consumer<Entity>>> pendingEntityActions = new HashMap<>();
+
+    public static void onEntityLoad(Entity entity) {
+        UUID entityId = entity.getUUID();
+        if (pendingEntityActions.containsKey(entityId)) {
+            List<Consumer<Entity>> actions = pendingEntityActions.remove(entityId);
+            for (Consumer<Entity> action : actions) {
+                action.accept(entity);
+            }
+        }
+    }
+
+    public static void clearPendingActions() {
+        pendingEntityActions.clear();
+    }
+
+    private static void queueOrExecute(Minecraft client, UUID entityId, Consumer<Entity> action) {
+        ClientLevel clientLevel = client.level;
+        if (clientLevel == null) {
+            return;
+        }
+
+        Entity entity = ((ClientLevelAccessor) clientLevel).callGetEntities().get(entityId);
+        if (entity == null) {
+            pendingEntityActions.computeIfAbsent(entityId, k -> new ArrayList<>()).add(action);
+        } else {
+            action.accept(entity);
+        }
+    }
+
     public static void receiveStartSingle(Minecraft client,
                                           ClientPacketListener clientPacketListener,
                                           FriendlyByteBuf buf,
                                           PacketSender responseSender) {
         UUID entityId = buf.readUUID();
-        RibbitEntity ribbit = (RibbitEntity) ((ClientLevelAccessor) client.level).callGetEntities().get(entityId);
 
         RibbitInstrument instrument = RibbitInstrumentModule.getInstrument(buf.readResourceLocation());
         int tickOffset = buf.readInt();
-
-        if (ribbit == null) {
-            RibbitsCommon.LOGGER.error("Received Start Music packet for a ribbit with UUID {} that doesn't exist!", entityId);
-            return;
-        }
 
         if (instrument == null) {
             RibbitsCommon.LOGGER.error("Tried to play music for a ribbit with null instrument!");
@@ -53,10 +78,18 @@ public class ClientPacketHandlerFabric {
             RibbitsCommon.LOGGER.error("Tried to play music for a ribbit with NONE instrument!");
             return;
         }
-        SoundEvent instrumentSoundEvent = instrument.getSoundEvent();
 
-        client.execute(() -> {
-            Minecraft.getInstance().getSoundManager().play(new RibbitInstrumentSoundInstance(ribbit, tickOffset, instrumentSoundEvent));
+        queueOrExecute(client, entityId, entity -> {
+            if (!(entity instanceof RibbitEntity ribbit)) {
+                RibbitsCommon.LOGGER.error("Tried to play music for a non-ribbit entity!");
+                return;
+            }
+
+            SoundEvent instrumentSoundEvent = instrument.getSoundEvent();
+
+            client.execute(() -> {
+                Minecraft.getInstance().getSoundManager().play(new RibbitInstrumentSoundInstance(ribbit, tickOffset, instrumentSoundEvent));
+            });
         });
     }
 
@@ -74,12 +107,6 @@ public class ClientPacketHandlerFabric {
         }
 
         for (int i = 0; i < entityIds.size(); i++) {
-            RibbitEntity ribbit = (RibbitEntity) ((ClientLevelAccessor) client.level).callGetEntities().get(entityIds.get(i));
-            if (ribbit == null) {
-                RibbitsCommon.LOGGER.error("Received Start Music All packet for a ribbit with UUID {} that doesn't exist!", entityIds.get(i));
-                return;
-            }
-
             RibbitInstrument instrument = RibbitInstrumentModule.getInstrument(instrumentIds.get(i));
             if (instrument == null) {
                 RibbitsCommon.LOGGER.error("Tried to play music in receiveStartAll for a ribbit with null instrument!");
@@ -90,10 +117,18 @@ public class ClientPacketHandlerFabric {
                 RibbitsCommon.LOGGER.error("Tried to play music in receiveStartAll for a ribbit with NONE instrument!");
                 return;
             }
-            SoundEvent instrumentSoundEvent = instrument.getSoundEvent();
 
-            client.execute(() -> {
-                Minecraft.getInstance().getSoundManager().play(new RibbitInstrumentSoundInstance(ribbit, tickOffset, instrumentSoundEvent));
+            queueOrExecute(client, entityIds.get(i), entity -> {
+                if (!(entity instanceof RibbitEntity ribbit)) {
+                    RibbitsCommon.LOGGER.error("Tried to play music in receiveStartAll for a non-ribbit entity!");
+                    return;
+                }
+
+                SoundEvent instrumentSoundEvent = instrument.getSoundEvent();
+
+                client.execute(() -> {
+                    Minecraft.getInstance().getSoundManager().play(new RibbitInstrumentSoundInstance(ribbit, tickOffset, instrumentSoundEvent));
+                });
             });
         }
     }
@@ -103,15 +138,11 @@ public class ClientPacketHandlerFabric {
                                    FriendlyByteBuf buf,
                                    PacketSender responseSender) {
         UUID entityId = buf.readUUID();
-        RibbitEntity ribbit = (RibbitEntity) ((ClientLevelAccessor) client.level).callGetEntities().get(entityId);
 
-        if (ribbit == null) {
-            RibbitsCommon.LOGGER.error("Received Stop Music packet for a ribbit with UUID {} that doesn't exist!", entityId);
-            return;
-        }
-
-        client.execute(() -> {
-            ((ISoundManagerDuck) Minecraft.getInstance().getSoundManager()).ribbits$stopRibbitsMusic(entityId);
+        queueOrExecute(client, entityId, entity -> {
+            client.execute(() -> {
+                ((ISoundManagerDuck) Minecraft.getInstance().getSoundManager()).ribbits$stopRibbitsMusic(entityId);
+            });
         });
     }
 
@@ -120,18 +151,16 @@ public class ClientPacketHandlerFabric {
                                           FriendlyByteBuf buf,
                                           PacketSender responseSender) {
         UUID performerId = buf.readUUID();
-        Entity performer = ((ClientLevelAccessor) client.level).callGetEntities().get(performerId);
 
-        if (performer == null) {
-            RibbitsCommon.LOGGER.error("Received Start Maraca packet for Player performer with UUID {} that doesn't exist!", performerId);
-            return;
-        } else if (!(performer instanceof Player)) {
-            RibbitsCommon.LOGGER.error("Received Start Maraca packet for non-Player performer with UUID {}!", performerId);
-            return;
-        }
+        queueOrExecute(client, performerId, performer -> {
+            if (!(performer instanceof Player playerPerformer)) {
+                RibbitsCommon.LOGGER.error("Received Start Maraca packet for non-Player performer with UUID {}!", performerId);
+                return;
+            }
 
-        client.execute(() -> {
-            Minecraft.getInstance().getSoundManager().play(new PlayerInstrumentSoundInstance((Player) performer, -1, SoundModule.MUSIC_MARACA.get()));
+            client.execute(() -> {
+                Minecraft.getInstance().getSoundManager().play(new PlayerInstrumentSoundInstance(playerPerformer, -1, SoundModule.MUSIC_MARACA.get()));
+            });
         });
     }
 
@@ -140,18 +169,11 @@ public class ClientPacketHandlerFabric {
                                          FriendlyByteBuf buf,
                                          PacketSender responseSender) {
         UUID performerId = buf.readUUID();
-        Entity performer = ((ClientLevelAccessor) client.level).callGetEntities().get(performerId);
 
-        if (performer == null) {
-            RibbitsCommon.LOGGER.error("Received Stop Maraca packet for Player performer with UUID {} that doesn't exist!", performerId);
-            return;
-        } else if (!(performer instanceof Player)) {
-            RibbitsCommon.LOGGER.error("Received Stop Maraca packet for non-Player performer with UUID {}!", performerId);
-            return;
-        }
-
-        client.execute(() -> {
-            ((ISoundManagerDuck) Minecraft.getInstance().getSoundManager()).ribbits$stopMaraca(performerId);
+        queueOrExecute(client, performerId, performer -> {
+            client.execute(() -> {
+                ((ISoundManagerDuck) Minecraft.getInstance().getSoundManager()).ribbits$stopMaraca(performerId);
+            });
         });
     }
 

--- a/Forge/src/main/java/com/yungnickyoung/minecraft/ribbits/client/RibbitsForgeClient.java
+++ b/Forge/src/main/java/com/yungnickyoung/minecraft/ribbits/client/RibbitsForgeClient.java
@@ -6,11 +6,13 @@ import com.yungnickyoung.minecraft.ribbits.client.render.RibbitRenderer;
 import com.yungnickyoung.minecraft.ribbits.module.BlockModule;
 import com.yungnickyoung.minecraft.ribbits.module.EntityTypeModule;
 import com.yungnickyoung.minecraft.ribbits.module.ParticleTypeModule;
+import com.yungnickyoung.minecraft.ribbits.network.ClientPacketHandlerForge;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.client.event.RegisterParticleProvidersEvent;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
@@ -30,6 +32,9 @@ public class RibbitsForgeClient {
         ItemBlockRenderTypes.setRenderLayer(BlockModule.TOADSTOOL.get(), RenderType.cutout());
         ItemBlockRenderTypes.setRenderLayer(BlockModule.UMBRELLA_LEAF.get(), RenderType.cutout());
         ItemBlockRenderTypes.setRenderLayer(BlockModule.MOSSY_OAK_DOOR.get(), RenderType.cutout());
+
+        MinecraftForge.EVENT_BUS.addListener(ClientPacketHandlerForge::onEntityJoinLevel);
+        MinecraftForge.EVENT_BUS.addListener(ClientPacketHandlerForge::onLevelUnload);
      }
 
     private static void registerRenderers(EntityRenderersEvent.RegisterRenderers event) {

--- a/Forge/src/main/java/com/yungnickyoung/minecraft/ribbits/network/ClientPacketHandlerForge.java
+++ b/Forge/src/main/java/com/yungnickyoung/minecraft/ribbits/network/ClientPacketHandlerForge.java
@@ -18,44 +18,81 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.event.entity.EntityJoinLevelEvent;
+import net.minecraftforge.event.level.LevelEvent;
 import net.minecraftforge.network.NetworkEvent;
 
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public class ClientPacketHandlerForge {
-    public static void handleStartSingleRibbitInstrument(RibbitMusicStartSingleS2CPacket packet, Supplier<NetworkEvent.Context> ctx) {
+    private static final Map<UUID, List<Consumer<Entity>>> pendingEntityActions = new HashMap<>();
+
+    public static void onEntityJoinLevel(EntityJoinLevelEvent event) {
+        if (!event.getLevel().isClientSide()) {
+            return;
+        }
+
+        Entity entity = event.getEntity();
+        UUID entityId = entity.getUUID();
+        if (pendingEntityActions.containsKey(entityId)) {
+            List<Consumer<Entity>> actions = pendingEntityActions.remove(entityId);
+            for (Consumer<Entity> action : actions) {
+                action.accept(entity);
+            }
+        }
+    }
+
+    public static void onLevelUnload(LevelEvent.Unload event) {
+        if (!event.getLevel().isClientSide()) {
+            return;
+        }
+
+        pendingEntityActions.clear();
+    }
+
+    private static void queueOrExecute(UUID entityId, Consumer<Entity> action) {
         ClientLevel clientLevel = Minecraft.getInstance().level;
+        if (clientLevel == null) {
+            return;
+        }
+
+        Entity entity = ((ClientLevelAccessor) clientLevel).callGetEntities().get(entityId);
+        if (entity == null) {
+            pendingEntityActions.computeIfAbsent(entityId, k -> new ArrayList<>()).add(action);
+        } else {
+            action.accept(entity);
+        }
+    }
+
+    public static void handleStartSingleRibbitInstrument(RibbitMusicStartSingleS2CPacket packet, Supplier<NetworkEvent.Context> ctx) {
         UUID entityId = packet.getRibbitId();
         RibbitInstrument instrument = RibbitInstrumentModule.getInstrument(packet.getInstrumentId());
         int tickOffset = packet.getTickOffset();
 
-        if (clientLevel != null) {
-            RibbitEntity ribbit = (RibbitEntity) ((ClientLevelAccessor) clientLevel).callGetEntities().get(entityId);
-
-            if (ribbit == null) {
-                RibbitsCommon.LOGGER.error("Received Start Music packet for a ribbit with UUID {} that doesn't exist!", entityId);
-                return;
-            }
-
-            if (instrument == null) {
-                RibbitsCommon.LOGGER.error("Tried to play music for a ribbit with null instrument!");
-                return;
-            }
-
-            if (instrument == RibbitInstrumentModule.NONE) {
-                RibbitsCommon.LOGGER.error("Tried to play music for a ribbit with NONE instrument!");
-                return;
-            }
-            SoundEvent instrumentSoundEvent = instrument.getSoundEvent();
-
-            Minecraft.getInstance().getSoundManager().play(new RibbitInstrumentSoundInstance(ribbit, tickOffset, instrumentSoundEvent));
+        if (instrument == null) {
+            RibbitsCommon.LOGGER.error("Tried to play music for a ribbit with null instrument!");
+            return;
         }
+
+        if (instrument == RibbitInstrumentModule.NONE) {
+            RibbitsCommon.LOGGER.error("Tried to play music for a ribbit with NONE instrument!");
+            return;
+        }
+
+        queueOrExecute(entityId, entity -> {
+            if (!(entity instanceof RibbitEntity ribbit)) {
+                RibbitsCommon.LOGGER.error("Tried to play music for a non-ribbit entity!");
+                return;
+            }
+
+            SoundEvent instrumentSoundEvent = instrument.getSoundEvent();
+            Minecraft.getInstance().getSoundManager().play(new RibbitInstrumentSoundInstance(ribbit, tickOffset, instrumentSoundEvent));
+        });
     }
 
     public static void handleStartAllRibbitInstruments(RibbitMusicStartAllS2CPacket packet, Supplier<NetworkEvent.Context> ctx) {
-        ClientLevel clientLevel = Minecraft.getInstance().level;
         List<UUID> entityIds = packet.getRibbitIds();
         List<ResourceLocation> instrumentIds = packet.getInstrumentIds();
         int tickOffset = packet.getTickOffset();
@@ -65,83 +102,54 @@ public class ClientPacketHandlerForge {
             return;
         }
 
-        if (clientLevel != null) {
-            for (int i = 0; i < entityIds.size(); i++) {
-                RibbitEntity ribbit = (RibbitEntity) ((ClientLevelAccessor) clientLevel).callGetEntities().get(entityIds.get(i));
-                if (ribbit == null) {
-                    RibbitsCommon.LOGGER.error("Received handleStartAllPacket for a ribbit with UUID {} that doesn't exist!", entityIds.get(i));
-                    return;
-                }
-
-                RibbitInstrument instrument = RibbitInstrumentModule.getInstrument(instrumentIds.get(i));
-                if (instrument == null) {
-                    RibbitsCommon.LOGGER.error("Tried to play music in handleStartAllPacket for a ribbit with null instrument!");
-                    return;
-                }
-
-                if (instrument == RibbitInstrumentModule.NONE) {
-                    RibbitsCommon.LOGGER.error("Tried to play music in handleStartAllPacket for a ribbit with NONE instrument!");
-                    return;
-                }
-                SoundEvent instrumentSoundEvent = instrument.getSoundEvent();
-
-                Minecraft.getInstance().getSoundManager().play(new RibbitInstrumentSoundInstance(ribbit, tickOffset, instrumentSoundEvent));
+        for (int i = 0; i < entityIds.size(); i++) {
+            RibbitInstrument instrument = RibbitInstrumentModule.getInstrument(instrumentIds.get(i));
+            if (instrument == null) {
+                RibbitsCommon.LOGGER.error("Tried to play music in handleStartAllPacket for a ribbit with null instrument!");
+                return;
             }
+
+            if (instrument == RibbitInstrumentModule.NONE) {
+                RibbitsCommon.LOGGER.error("Tried to play music in handleStartAllPacket for a ribbit with NONE instrument!");
+                return;
+            }
+
+            queueOrExecute(entityIds.get(i), entity -> {
+                if (!(entity instanceof RibbitEntity ribbit)) {
+                    RibbitsCommon.LOGGER.error("Tried to play music in handleStartAllPacket for a non-ribbit entity!");
+                    return;
+                }
+
+                SoundEvent instrumentSoundEvent = instrument.getSoundEvent();
+                Minecraft.getInstance().getSoundManager().play(new RibbitInstrumentSoundInstance(ribbit, tickOffset, instrumentSoundEvent));
+            });
         }
     }
 
     public static void handleStopSingleRibbitInstrument(RibbitMusicStopSingleS2CPacket packet, Supplier<NetworkEvent.Context> ctx) {
-        ClientLevel clientLevel = Minecraft.getInstance().level;
         UUID entityId = packet.getRibbitId();
-
-        if (clientLevel != null) {
-            RibbitEntity ribbit = (RibbitEntity) ((ClientLevelAccessor) clientLevel).callGetEntities().get(entityId);
-
-            if (ribbit == null) {
-                RibbitsCommon.LOGGER.error("Received Stop Music packet for a ribbit with UUID {} that doesn't exist!", entityId);
-                return;
-            }
-
-            ((ISoundManagerDuck) Minecraft.getInstance().getSoundManager()).ribbits$stopRibbitsMusic(entityId);
-        }
+        queueOrExecute(entityId, entity -> ((ISoundManagerDuck) Minecraft.getInstance().getSoundManager()).ribbits$stopRibbitsMusic(entityId));
     }
 
     public static void handleStartPlayerInstrument(PlayerMusicStartS2CPacket packet, Supplier<NetworkEvent.Context> ctx) {
-        ClientLevel clientLevel = Minecraft.getInstance().level;
         UUID performerId = packet.getPerformerId();
 
-        if (clientLevel != null) {
-            Entity performer = ((ClientLevelAccessor) clientLevel).callGetEntities().get(performerId);
-
-            if (performer == null) {
-                RibbitsCommon.LOGGER.error("Received Start Maraca packet for Player performer with UUID {} that doesn't exist!", performerId);
-                return;
-            } else if (!(performer instanceof Player)) {
+        queueOrExecute(performerId, performer -> {
+            if (!(performer instanceof Player playerPerformer)) {
                 RibbitsCommon.LOGGER.error("Received Start Maraca packet for non-Player performer with UUID {}!", performerId);
                 return;
             }
 
-            Minecraft.getInstance().getSoundManager().play(new PlayerInstrumentSoundInstance((Player) performer, -1, SoundModule.MUSIC_MARACA.get()));
-        }
+            Minecraft.getInstance().getSoundManager().play(new PlayerInstrumentSoundInstance(playerPerformer, -1, SoundModule.MUSIC_MARACA.get()));
+        });
     }
 
     public static void handleStopPlayerInstrument(PlayerMusicStopS2CPacket packet, Supplier<NetworkEvent.Context> ctx) {
-        ClientLevel clientLevel = Minecraft.getInstance().level;
         UUID performerId = packet.getPerformerId();
 
-        if (clientLevel != null) {
-            Entity performer = ((ClientLevelAccessor) clientLevel).callGetEntities().get(performerId);
-
-            if (performer == null) {
-                RibbitsCommon.LOGGER.error("Received Stop Maraca packet for Player performer with UUID {} that doesn't exist!", performerId);
-                return;
-            } else if (!(performer instanceof Player)) {
-                RibbitsCommon.LOGGER.error("Received Stop Maraca packet for non-Player performer with UUID {}!", performerId);
-                return;
-            }
-
+        queueOrExecute(performerId, performer -> {
             ((ISoundManagerDuck) Minecraft.getInstance().getSoundManager()).ribbits$stopMaraca(performerId);
-        }
+        });
     }
 
     public static void handleToggleSupporterHat(ToggleSupporterHatS2CPacket packet, Supplier<NetworkEvent.Context> ctx) {


### PR DESCRIPTION
This PR fixes these kinds of errors (#40):
```
Received Start Music packet for a ribbit with UUID ... that doesn't exist!
```

### Why this happens

Previously, there was a race condition where music packets were sometimes sent to/handled by the client before the vanilla `ClientboundAddEntityPacket` with the corresponding RibbitEntity was received/handled. This led to the entity being `null`.

I reproduced this consistently by adding this breakpoint:
![breakpoint](https://github.com/user-attachments/assets/f81557c6-35cd-4aa6-925f-fcb09e493179)

... and running these steps:
1. Running a dedicated server
2. Configuring the client to have the minimal view/simulation distance
3. Joining the server
4. Approaching a ribbit village

This always resulted in outputs like this:
![output](https://github.com/user-attachments/assets/4e160f77-07af-4803-854e-d2a23df2c044)

As you can see, the actual entities are loaded after the music packet is received.

### The fix

I fixed this by introducing a `queueOrExecute` method in the packet handlers. If the entity is found, the action (e.g. playing the instrument sound) is executed right away, however, if the entity is `null`, the action is queued. I then added an event listener for `EntityJoinLevelEvent` (Forge) / `ENTITY_LOAD` (Fabric) to execute the pending queued actions once the entity ID matches.

The pending actions also need to be cleared on world unload to avoid memory leaks. To do that, I added another event listener for `LevelEvent.Unload` (Forge) / `ClientPlayConnectionEvents.DISCONNECT` (Fabric).

>You may want to move the event handling somewhere else. I am not familiar with your preferred package structure, so I just put it in the packet handler classes for now.

>Maybe some kind of sound offset handling is also necessary for this? I just saw something about sound offsets in the code but didn't look into this more... The music sounded great in my testing though :D

Hope this helps :)