### PR TITLE
Fix duplicate Sorcerer spawn egg item registration on Fabric 1.20.1.

### DIFF
--- a/Fabric/src/main/java/com/yungnickyoung/minecraft/ribbits/mixin/mixins/SpawnEggItemMixinFabric.java
+++ b/Fabric/src/main/java/com/yungnickyoung/minecraft/ribbits/mixin/mixins/SpawnEggItemMixinFabric.java
@@ -2,8 +2,10 @@ package com.yungnickyoung.minecraft.ribbits.mixin.mixins;
 
 import com.google.common.collect.Iterables;
 import com.yungnickyoung.minecraft.ribbits.module.ItemModule;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.SpawnEggItem;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -22,11 +24,19 @@ public class SpawnEggItemMixinFabric {
         Iterable<SpawnEggItem> original = cir.getReturnValue();
         List<SpawnEggItem> allEggs = new ArrayList<>();
         original.forEach(allEggs::add);
-        allEggs.add((SpawnEggItem) ItemModule.RIBBIT_FISHERMAN_SPAWN_EGG.get());
-        allEggs.add((SpawnEggItem) ItemModule.RIBBIT_GARDENER_SPAWN_EGG.get());
-        allEggs.add((SpawnEggItem) ItemModule.RIBBIT_MERCHANT_SPAWN_EGG.get());
-        allEggs.add((SpawnEggItem) ItemModule.RIBBIT_NITWIT_SPAWN_EGG.get());
-        allEggs.add((SpawnEggItem) ItemModule.RIBBIT_SORCERER_SPAWN_EGG.get());
+        addEgg(allEggs, ItemModule.RIBBIT_FISHERMAN_SPAWN_EGG.get());
+        addEgg(allEggs, ItemModule.RIBBIT_GARDENER_SPAWN_EGG.get());
+        addEgg(allEggs, ItemModule.RIBBIT_MERCHANT_SPAWN_EGG.get());
+        addEgg(allEggs, ItemModule.RIBBIT_NITWIT_SPAWN_EGG.get());
+        addEgg(allEggs, ItemModule.RIBBIT_SORCERER_SPAWN_EGG.get());
         cir.setReturnValue(Iterables.unmodifiableIterable(allEggs));
+    }
+
+    @Unique
+    private static void addEgg(List<SpawnEggItem> list, Item egg) {
+        SpawnEggItem spawnEggItem = (SpawnEggItem) egg;
+        if (!list.contains(spawnEggItem)) {
+            list.add(spawnEggItem);
+        }
     }
 }


### PR DESCRIPTION
I applied [your patch](https://github.com/yungnickyoung/Ribbits/commit/b1cde776bc1eeb613cf3e21014d9397b213290e7) for Fabric 1.21.1 to Fabric 1.20.1.

Feel free to do whatever with this PR.