### PR TITLE
Ribbit pathfinding fixes

### DIFF
--- a/Common/src/main/java/com/yungnickyoung/minecraft/ribbits/entity/RibbitEntity.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/ribbits/entity/RibbitEntity.java
@@ -31,16 +31,13 @@ import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
+import net.minecraft.tags.FluidTags;
 import net.minecraft.util.Mth;
 import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.entity.AgeableMob;
-import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.ExperienceOrb;
-import net.minecraft.world.entity.MobSpawnType;
-import net.minecraft.world.entity.SpawnGroupData;
+import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.goal.FloatGoal;
@@ -48,6 +45,7 @@ import net.minecraft.world.entity.ai.goal.LookAtPlayerGoal;
 import net.minecraft.world.entity.ai.goal.OpenDoorGoal;
 import net.minecraft.world.entity.ai.goal.PanicGoal;
 import net.minecraft.world.entity.ai.navigation.GroundPathNavigation;
+import net.minecraft.world.entity.ai.navigation.PathNavigation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -57,6 +55,7 @@ import net.minecraft.world.item.trading.MerchantOffers;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.ServerLevelAccessor;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.pathfinder.*;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
 import software.bernie.geckolib.animatable.GeoEntity;
@@ -151,7 +150,8 @@ public class RibbitEntity extends AgeableMob implements GeoEntity, Merchant {
     public RibbitEntity(EntityType<RibbitEntity> entityType, Level level) {
         super(entityType, level);
 
-        ((GroundPathNavigation) this.getNavigation()).setCanOpenDoors(true);
+        this.setPathfindingMalus(BlockPathTypes.WATER, 0.0F);
+        this.setPathfindingMalus(BlockPathTypes.WATER_BORDER, 0.0F);
 
         this.reassessGoals();
     }
@@ -161,7 +161,7 @@ public class RibbitEntity extends AgeableMob implements GeoEntity, Merchant {
         super.registerGoals();
         this.goalSelector.addGoal(0, new OpenDoorGoal(this, true));
         this.goalSelector.addGoal(0, new FloatGoal(this));
-        this.goalSelector.addGoal(1, new RibbitGoHomeGoal(this, 1.8f, 1f, 60));
+        this.goalSelector.addGoal(1, new RibbitGoHomeGoal(this, 3.0F, 1.0F, 60));
         this.goalSelector.addGoal(2, new PanicGoal(this, 1.5D));
         this.goalSelector.addGoal(3, new RibbitStopAndStareAtFrogGoal(this, 4.0F));
         this.goalSelector.addGoal(4, new LookAtPlayerGoal(this, Player.class, 8.0F));
@@ -326,8 +326,7 @@ public class RibbitEntity extends AgeableMob implements GeoEntity, Merchant {
         ItemStack itemStack = player.getItemInHand(interactionHand);
 
         if (player.isSecondaryUseActive() && itemStack.is(Items.AMETHYST_SHARD)) {
-            this.homePosition = this.blockPosition();
-            this.level().broadcastEntityEvent(this, (byte) 12);
+            this.setNewHomePosition();
 
             if (!player.getAbilities().instabuild) {
                 itemStack.shrink(1);
@@ -349,6 +348,16 @@ public class RibbitEntity extends AgeableMob implements GeoEntity, Merchant {
             return InteractionResult.sidedSuccess(this.level().isClientSide);
         }
         return super.mobInteract(player, interactionHand);
+    }
+
+    private void setNewHomePosition() {
+        this.homePosition = this.blockPosition();
+        this.level().broadcastEntityEvent(this, (byte) 12);
+
+        this.fishGoal.stopFishing();
+        this.waterCropsGoal.stopWateringCrops();
+        this.musicGoal.stopPlayingMusic();
+        this.getNavigation().stop();
     }
 
     public void reassessGoals() {
@@ -872,5 +881,51 @@ public class RibbitEntity extends AgeableMob implements GeoEntity, Merchant {
     @Override
     public boolean isClientSide() {
         return this.level().isClientSide();
+    }
+
+    @Override
+    protected @NotNull PathNavigation createNavigation(@NotNull Level level) {
+        return new RibbitPathNavigation(this, level);
+    }
+
+    private static class RibbitPathNavigation extends GroundPathNavigation {
+        public RibbitPathNavigation(Mob mob, Level level) {
+            super(mob, level);
+        }
+
+        @Override
+        protected @NotNull PathFinder createPathFinder(int maxVisitedNodes) {
+            this.nodeEvaluator = new WalkNodeEvaluator() {
+                @Override
+                protected boolean isAmphibious() {
+                    return true;
+                }
+            };
+
+            this.nodeEvaluator.setCanPassDoors(true);
+            this.nodeEvaluator.setCanOpenDoors(true);
+            this.nodeEvaluator.setCanFloat(true);
+
+            return new PathFinder(this.nodeEvaluator, maxVisitedNodes);
+        }
+
+        @Override
+        protected boolean hasValidPathType(@NotNull BlockPathTypes pathType) {
+            if (pathType == BlockPathTypes.WATER || pathType == BlockPathTypes.WATER_BORDER) {
+                return true;
+            }
+
+            return super.hasValidPathType(pathType);
+        }
+
+        @Override
+        public boolean isStableDestination(@NotNull BlockPos pos) {
+            return this.level.getFluidState(pos).is(FluidTags.WATER) || super.isStableDestination(pos);
+        }
+
+        @Override
+        public boolean canCutCorner(@NotNull BlockPathTypes pathType) {
+            return pathType != BlockPathTypes.WATER_BORDER && super.canCutCorner(pathType);
+        }
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/ribbits/entity/RibbitEntity.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/ribbits/entity/RibbitEntity.java
@@ -177,7 +177,7 @@ public class RibbitEntity extends AgeableMob implements GeoEntity, Merchant {
                 this.setHealth(Math.min(this.getHealth() + 1, this.getMaxHealth()));
             }
 
-            if (this.onGround() && this.isUmbrellaFalling()) {
+            if ((this.onGround() || this.isInWater()) && this.isUmbrellaFalling()) {
                 this.setUmbrellaFalling(false);
             }
 

--- a/Common/src/main/java/com/yungnickyoung/minecraft/ribbits/entity/goal/RibbitFishGoal.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/ribbits/entity/goal/RibbitFishGoal.java
@@ -26,6 +26,7 @@ public class RibbitFishGoal extends Goal {
     private int ticksFishing;
     private BlockPos waterPos;
     private Vec3 dryPos;
+    private boolean shouldStop = false;
 
     public RibbitFishGoal(RibbitEntity ribbit, double range, float speedModifier, int minRequiredFishTicks, int maxRequiredFishTicks) {
         this.ribbit = ribbit;
@@ -51,6 +52,7 @@ public class RibbitFishGoal extends Goal {
         this.waterPos = null;
         this.dryPos = null;
         this.ticksFishing = 0;
+        this.shouldStop = false;
 
         this.ribbit.setFishing(false);
     }
@@ -104,6 +106,10 @@ public class RibbitFishGoal extends Goal {
 
     @Override
     public boolean canContinueToUse() {
+        if (shouldStop) {
+            return false;
+        }
+
         Iterable<BlockPos> nearbyPositions = BlockPos.betweenClosed(Mth.floor(this.ribbit.getX() - 1.5), Mth.floor(this.ribbit.getY() - 1.5), Mth.floor(this.ribbit.getZ() - 1.5), Mth.floor(this.ribbit.getX() + 1.5), this.ribbit.getBlockY(), Mth.floor(this.ribbit.getZ() + 1.5));
 
         boolean waterNearby = false;
@@ -133,5 +139,9 @@ public class RibbitFishGoal extends Goal {
             this.ribbit.setFishing(false);
             this.ribbit.getNavigation().moveTo(this.dryPos.x(), this.dryPos.y(), this.dryPos.z(), this.speedModifier * waterModifier);
         }
+    }
+
+    public void stopFishing() {
+        this.shouldStop = true;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/ribbits/entity/goal/RibbitGoHomeGoal.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/ribbits/entity/goal/RibbitGoHomeGoal.java
@@ -1,8 +1,10 @@
 package com.yungnickyoung.minecraft.ribbits.entity.goal;
 
 import com.yungnickyoung.minecraft.ribbits.entity.RibbitEntity;
+import net.minecraft.core.BlockPos;
+import net.minecraft.tags.FluidTags;
 import net.minecraft.world.entity.ai.goal.Goal;
-import net.minecraft.world.entity.ai.goal.RandomStrollGoal;
+import net.minecraft.world.entity.ai.util.DefaultRandomPos;
 import net.minecraft.world.phys.Vec3;
 
 import java.util.EnumSet;
@@ -12,6 +14,7 @@ public class RibbitGoHomeGoal extends Goal {
     private final float homePointRange;
     private final float speedModifier;
     private final int interval;
+    private boolean stuck;
 
     public RibbitGoHomeGoal(RibbitEntity ribbit, float homePointRange, float speedModifier, int interval) {
         this.ribbit = ribbit;
@@ -24,10 +27,11 @@ public class RibbitGoHomeGoal extends Goal {
 
     @Override
     public boolean canUse() {
-        if (this.ribbit.distanceToSqr(this.ribbit.getHomePosition().getX(),
-                this.ribbit.getHomePosition().getY(),
-                this.ribbit.getHomePosition().getZ()) <= this.homePointRange * this.homePointRange &&
-                this.ribbit.getRandom().nextInt(RandomStrollGoal.reducedTickDelay(this.interval)) != 0) {
+        if (this.ribbit.getRandom().nextInt(RibbitGoHomeGoal.reducedTickDelay(interval)) != 0) {
+            return false;
+        }
+
+        if (this.ribbit.getHomePosition().closerToCenterThan(this.ribbit.position(), homePointRange)) {
             return false;
         }
 
@@ -35,35 +39,64 @@ public class RibbitGoHomeGoal extends Goal {
     }
 
     @Override
-    public boolean canContinueToUse() {
-        return !this.ribbit.getNavigation().isDone() && !this.ribbit.isVehicle();
+    public void start() {
+        this.stuck = false;
     }
 
     @Override
-    public boolean requiresUpdateEveryTick() {
-        return true;
+    public boolean canContinueToUse() {
+        return !this.ribbit.isVehicle() &&
+                !this.ribbit.getHomePosition().closerToCenterThan(this.ribbit.position(), homePointRange) &&
+                !this.stuck;
     }
 
     @Override
     public void tick() {
-        super.tick();
-
         float waterModifier = this.ribbit.isInWater() ? RibbitEntity.WATER_SPEED_MULTIPLIER : 1.0f;
         this.ribbit.getNavigation().setSpeedModifier(this.speedModifier * waterModifier);
-    }
 
-    @Override
-    public void start() {
-        Vec3 distanceVariance = new Vec3(
-                this.ribbit.getRandom().nextFloat() * this.homePointRange * 2 - this.homePointRange,
-                this.ribbit.getRandom().nextFloat() * this.homePointRange * 2 - this.homePointRange,
-                this.ribbit.getRandom().nextFloat() * this.homePointRange * 2 - this.homePointRange);
+        BlockPos homePos = this.ribbit.getHomePosition();
 
-        float waterModifier = this.ribbit.isInWater() ? RibbitEntity.WATER_SPEED_MULTIPLIER : 1.0f;
+        if (this.ribbit.getNavigation().isDone()) {
+            boolean closeEnoughForDirectNavigation = homePos.closerToCenterThan(this.ribbit.position(), 16.0);
+            if (closeEnoughForDirectNavigation) {
+                Vec3 distanceVariance = new Vec3(
+                        this.ribbit.getRandom().nextFloat() * this.homePointRange * 2 - this.homePointRange,
+                        this.ribbit.getRandom().nextFloat() * this.homePointRange * 2 - this.homePointRange,
+                        this.ribbit.getRandom().nextFloat() * this.homePointRange * 2 - this.homePointRange);
 
-        this.ribbit.getNavigation().moveTo(distanceVariance.x() + this.ribbit.getHomePosition().getX(),
-                distanceVariance.y() + this.ribbit.getHomePosition().getY(),
-                distanceVariance.z() + this.ribbit.getHomePosition().getZ(), this.speedModifier * waterModifier);
+                this.ribbit.getNavigation().moveTo(distanceVariance.x() + homePos.getX(),
+                        distanceVariance.y() + homePos.getY(),
+                        distanceVariance.z() + homePos.getZ(),
+                        this.speedModifier * waterModifier);
+            } else {
+                Vec3 homePosVec = Vec3.atBottomCenterOf(homePos);
+
+                Vec3 nextPos = DefaultRandomPos.getPosTowards(this.ribbit, 16, 3, homePosVec, Math.PI / 10);
+                if (nextPos == null) {
+                    nextPos = DefaultRandomPos.getPosTowards(this.ribbit, 24, 7, homePosVec, Math.PI / 2);
+                }
+
+                if (nextPos == null) {
+                    this.stuck = true;
+                } else {
+                    BlockPos targetBlock = BlockPos.containing(nextPos);
+
+                    if (this.ribbit.level().getFluidState(targetBlock).is(FluidTags.WATER)) {
+                        while (this.ribbit.level().getFluidState(targetBlock.above()).is(FluidTags.WATER)) {
+                            targetBlock = targetBlock.above();
+                        }
+                        nextPos = Vec3.atBottomCenterOf(targetBlock);
+                    }
+
+                    this.ribbit.getNavigation().moveTo(
+                            nextPos.x,
+                            nextPos.y,
+                            nextPos.z,
+                            this.speedModifier * waterModifier);
+                }
+            }
+        }
     }
 
     @Override

--- a/Common/src/main/java/com/yungnickyoung/minecraft/ribbits/entity/goal/RibbitPlayMusicGoal.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/ribbits/entity/goal/RibbitPlayMusicGoal.java
@@ -29,6 +29,7 @@ public class RibbitPlayMusicGoal extends Goal {
     private double pathedTargetY;
     private double pathedTargetZ;
     private int ticksUntilNextPathRecalculation;
+    private boolean shouldStop = false;
 
     public RibbitPlayMusicGoal(RibbitEntity ribbit, double speedModifier, int minRequiredPlayTicks, int maxRequiredPlayTicks) {
         this.ribbit = ribbit;
@@ -61,7 +62,7 @@ public class RibbitPlayMusicGoal extends Goal {
 
     @Override
     public boolean canContinueToUse() {
-        return !this.ribbit.isUmbrellaFalling() && !this.ribbit.isDeadOrDying() && (this.ribbit.getPlayingInstrument() || this.ribbit.getMasterRibbit() == null || !this.ribbit.getMasterRibbit().isBandFull());
+        return !this.shouldStop && !this.ribbit.isUmbrellaFalling() && !this.ribbit.isDeadOrDying() && (this.ribbit.getPlayingInstrument() || this.ribbit.getMasterRibbit() == null || !this.ribbit.getMasterRibbit().isBandFull());
     }
 
     @Override
@@ -84,7 +85,7 @@ public class RibbitPlayMusicGoal extends Goal {
 
     @Override
     public void stop() {
-        if (this.ribbit.getMasterRibbit() != null) {
+        if (this.ribbit.getMasterRibbit() != null && !this.ribbit.isMasterRibbit()) {
             this.ribbit.getMasterRibbit().removeRibbitFromPlayingMusic(this.ribbit);
             this.ribbit.getMasterRibbit().removeBandMember(this.ribbit.getRibbitData().getInstrument());
         }
@@ -97,6 +98,11 @@ public class RibbitPlayMusicGoal extends Goal {
         this.ribbit.setTicksPlayingMusic(0);
 
         this.ribbit.setInstrument(RibbitInstrumentModule.NONE);
+
+        if (this.shouldStop) {
+            this.ribbit.setMasterRibbit(null);
+            this.shouldStop = false;
+        }
     }
 
     @Override
@@ -106,8 +112,8 @@ public class RibbitPlayMusicGoal extends Goal {
 
     @Override
     public boolean isInterruptable() {
-        return (this.ribbit.getLastHurtByMob() != null || this.ribbit.isFreezing() || this.ribbit.isOnFire()) ||
-                this.ribbit.getTicksPlayingMusic() > this.requiredPlayTicks;
+        return this.shouldStop || (this.ribbit.getLastHurtByMob() != null || this.ribbit.isFreezing() ||
+                this.ribbit.isOnFire()) || this.ribbit.getTicksPlayingMusic() > this.requiredPlayTicks;
     }
 
     @Override
@@ -132,8 +138,13 @@ public class RibbitPlayMusicGoal extends Goal {
 
         RibbitEntity masterRibbit = this.ribbit.getMasterRibbit();
 
-        this.ribbit.getLookControl().setLookAt(masterRibbit, 30.0f, 30.0f);
         double d = this.ribbit.distanceToSqr(masterRibbit.getX(), masterRibbit.getY(), masterRibbit.getZ());
+        if (d > 64 * 64) {
+            this.shouldStop = true;
+            return;
+        }
+
+        this.ribbit.getLookControl().setLookAt(masterRibbit, 30.0f, 30.0f);
         this.ticksUntilNextPathRecalculation = Math.max(this.ticksUntilNextPathRecalculation - 1, 0);
 
         float waterModifier = this.ribbit.isInWater() ? RibbitEntity.WATER_SPEED_MULTIPLIER : 1.0f;
@@ -221,5 +232,9 @@ public class RibbitPlayMusicGoal extends Goal {
 
             this.ribbit.setTicksPlayingMusic(this.ribbit.getTicksPlayingMusic() + 1);
         }
+    }
+
+    public void stopPlayingMusic() {
+        this.shouldStop = true;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/ribbits/entity/goal/RibbitWaterCropsGoal.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/ribbits/entity/goal/RibbitWaterCropsGoal.java
@@ -117,7 +117,7 @@ public class RibbitWaterCropsGoal extends Goal {
                     tryGrowCropAtPos(this.ribbit.level(), pos);
                 }
 
-                this.wateringTicks = -1; // Prevents watering again until the goal is stopped
+                this.stopWateringCrops(); // Prevents watering again until the goal is stopped
             }
         } else if (this.ribbit.distanceToSqr(this.targetCropPos.getX() + 0.5f, this.targetCropPos.getY(), this.targetCropPos.getZ() + 0.5f) < 3.0f) {
             this.ribbit.setWatering(false);
@@ -158,5 +158,9 @@ public class RibbitWaterCropsGoal extends Goal {
                 Mth.floor(this.ribbit.getX() + 1.0),
                 Mth.floor(this.ribbit.getBlockY() + 1.0),
                 Mth.floor(this.ribbit.getZ() + 1.0));
+    }
+
+    public void stopWateringCrops() {
+        this.wateringTicks = -1;
     }
 }


### PR DESCRIPTION
This PR fixes #16 and fixes #42.

### Performance issues

I confirmed the performance issues from #16 by creating a superflat singleplayer world, spawning a ribbit in a fenced-in area, and running this command to set the home position to a place ~1000 blocks away:

```
/data modify @e[type=ribbits:ribbit,sort=nearest,limit=1] HomePosX 1000
```

The ms/ticks value on the F3 menu increased from 1-2 ms/tick to ~40 ms/tick after running the command.

I suspect this happened because the navigation calculates the whole path to the home position every tick, as the navigation stopped immediately because of the fence.

I fixed this by reworking `RibbitGoHomeGoal` to select a random position 16-24 blocks away in the general direction of the home position and navigating to that (so it doesn't calculate the whole path at once, just a small part). For this, I adapted the logic from vanilla's `Turtle.TurtleGoHomeGoal`.

To make this work correctly, I also had to modify the navigation of the `RibbitEntity` a bit so water blocks are treated as valid targets (ribbits could get stuck in large bodies of water otherwise). I couldn't just use the standard `AmphibiousPathNavigation` because the door-related AI goals only work with `GroundPathNavigation`, so I had to extend and modify it accordingly.

In my testing, it worked well, but you may want to test it yourself to confirm it works correctly.

For distances <= 16 blocks, the goal switches to direct navigation as in the previous logic.

### Pathfinding to old home despite new home being set

#42 was a bit tough to figure out, but I confirmed it as well. I suspected `RibbitGoHomeGoal` to be the culprit here too because the navigation was never manually stopped when the home was reset. However, it seems like that happened automatically a few seconds later. Still, I added a `getNavigation().stop()` call when setting a new home just to be safe.

After a bit more testing, I figured out the real issue: the profession-specific goals. The ribbits weren't actually pathfinding to their old home position, but to their "objectives" near the old home. Fisherman ribbits, for example, tried to pathfind to a previously determined `dryPos` which could be thousands of blocks away (`RibbitFishGoal`). Nitwits would wander off to their potential master ribbit (`RibbitPlayMusicGoal`), and gardeners would try to find their way back to a previously set `targetCropPos` (`RibbitWaterCropsGoal`).

I added methods that reset these goals, which are called when a new home is set.

### Small bonus issue

While testing the navigation, I found that ribbits would continue to fall to the bottom of the sea when their umbrella was out because the check only accounted for `onGround()`. I made it also account for `isInWater()` now, so the ribbit will put away the umbrella and start floating naturally.